### PR TITLE
Add fix for sliding columns and printing

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,12 +19,9 @@ def Main():
     if 'new_student' in form_submitted:
         student_info = {}
 
-        student_info['name'], student_info['image_link'], student_info['usc_id'], student_info['major'], student_info['years'] = form_submitted['name'], form_submitted['image_link'], form_submitted['usc_id'], form_submitted['major'], [form_submitted['year_of_joining']]
-        
+        student_info['name'], student_info['usc_id'], student_info['major'], student_info['years'] = form_submitted['name'], form_submitted['usc_id'], form_submitted['major'], [form_submitted['year_of_joining']]
+        student_info['image_link']=""
         student_info[form_submitted['year_of_joining']] = {'fall':[],'spring':[],'summer':[]}
-
-        if student_info['image_link']=='':
-            student_info['image_link'] = 'https://media3.giphy.com/media/bhJqCi6LVaDPG/giphy.gif'
 
         if student_info['usc_id'] in [x['usc_id'] for x in students_info]:
             error = 'USC id matches to an existing users'
@@ -44,7 +41,7 @@ def Main():
 
 
     students_paths = glob.glob(student_data_path+'*.csv')
-    students_info = [read_student_info(student_path,check_dict) for student_path in students_paths]
+    students_info = sorted([read_student_info(student_path,check_dict) for student_path in students_paths], key = lambda x: x["name"])
     
     return render_template('main.html', students_info=students_info, message=message, error = error)
 

--- a/helpers/score.py
+++ b/helpers/score.py
@@ -12,7 +12,7 @@ def bcs(courses_taken):
     phd = sum(list(map(int,courses_taken['c_credits'].values)))
     res['area_requirements']= []
     if '621' in c_numbers:
-        res['area_requirements'] = "All Requirements Met" #all satisfied
+        res['area_requirements'] = ["All Requirements Met"] #all satisfied
     else:
         if not all(c in c_numbers for c in ['500','501']):
             res['area_requirements'] = ["PSYC 500/501"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.1
-Jinja2==2.11.3
+Jinja2==2.10.3
 numpy==1.18.1
 pandas==1.0.1
 glob2==0.7

--- a/static/css/print.css
+++ b/static/css/print.css
@@ -1,0 +1,1 @@
+.no-print { display: none; }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -45,6 +45,11 @@ tbody tr {
     color: #da8db3;
 }
 
+tr.years-row {
+    border-bottom: solid #825F77;
+    border-top: solid #825F77;
+}
+
 button.remove {
     color: #464646;
     background-color: inherit;
@@ -55,8 +60,6 @@ button.remove {
 
 div.box {
     border: dotted 0.025em rgb(172, 164, 169);
-    width: 50%;
-    float: left;
     padding: 5px;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,10 +18,10 @@
         <button type="button" class="btn btn-secondary">All Students</button>
     </a>
     <a href="/courses">
-        <button type="button" class="btn btn-secondary">All courses</button>
+        <button type="button" class="btn btn-secondary">All Courses</button>
     </a>
     <a href="/petitions/{{usc_id}}">
-        <button type="button" class="btn btn-secondary">All petitioned Courses</button>
+        <button type="button" class="btn btn-secondary">Petitioned Courses</button>
     </a>
 
     <button style="float: right;" type="button" class="btn btn-secondary" onclick="window.print()">Print</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,26 +9,30 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
         integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+    <link rel="stylesheet" type="text/css" media="print" href="{{ url_for('static', filename='css/print.css') }}" />
 
     <title>Course Planner</title>
 </head>
 
 <body class="container-fluid">
-    <a href="/">
-        <button type="button" class="btn btn-secondary">All Students</button>
-    </a>
-    <a href="/courses">
-        <button type="button" class="btn btn-secondary">All Courses</button>
-    </a>
-    <a href="/petitions/{{usc_id}}">
-        <button type="button" class="btn btn-secondary">Petitioned Courses</button>
-    </a>
+    <div class="no-print">
+        <a href="/">
+            <button type="button" class="btn btn-secondary">All Students</button>
+        </a>
+        <a href="/courses">
+            <button type="button" class="btn btn-secondary">All Courses</button>
+        </a>
+        <a href="/petitions/{{usc_id}}">
+            <button type="button" class="btn btn-secondary">Petitioned Courses</button>
+        </a>
+    
 
     <button style="float: right;" type="button" class="btn btn-secondary" onclick="window.print()">Print</button>
-
+</div>
     <div>
         <h2 class="mainheading"> Course Planner for {{student_info['name']}} </h2>
         <hr> <br>
+        <div class = "no-print">
         {% if message %}
         <div class="alert alert-success" role="alert">{{message}}</div>
         {% endif %}
@@ -39,10 +43,11 @@
         <div class="alert alert-danger" role="alert">{{error}}</div>
         {% endif %}
     </div>
+</div>
 
     <form class="form" method="POST">
 
-        <label for="major">Change major: </label>
+        <label class = "no-print" for="major">Change major: </label>
 
         <input list="major_names" size="25" autocomplete="off" type="text" name="major"
             placeholder="{{student_info['major']}}">
@@ -53,12 +58,12 @@
             <option value="Quantitative Psychology">
         </datalist>
 
-        <button class="btnSuccess" type="submit" name="major">Submit</button>
+        <button  class="btnSuccess no-print" type="submit" name="major">Submit</button>
     </form>
     <br />
 
     <button data-toggle="modal" data-target="#myModal" class="btnSuccess">
-        <i class="far fa-star"></i>Add new Course
+        <i class="far fa-star no-print"></i>Add new Course
     </button>
 
     <div>
@@ -147,115 +152,125 @@
     </div>
 
     <form method="POST">
-        <textarea name="general_notes"
-            rows="5" cols="120"
+        <textarea name="general_notes" rows="5" cols="120"
             placeholder="Enter your notes here">{{ student_info['notes']['general'] }}</textarea><br>
-        <button type="submit" id="notes_submit" class="btn btn-secondary" name="save_notes">Save</button>
+        <button type="submit" id="notes_submit" class="btn btn-secondary no-print" name="save_notes">Save</button>
     </form>
 
-      
-    {% if student_info['years'] %}
-    {% for each_year in student_info['years'] %}
+    <table>
 
-    <div class="box">
-        <div class="yearHeading">
-            <form method="POST">
+        {% if student_info['years'] %}
+        {% for each_year in student_info['years'] %}
+        {% if loop.cycle('odd','even') == 'odd' %}
+        <tr class="years-row">
+            {% endif %}
+            <td>
+                <div class="box">
+                    <div class="yearHeading">
+                        <form method="POST">
 
-                <span class="year">Year {{each_year}}</span>
-                <button class="remove" type="submit" name="remove_year" value=" Remove  {{each_year}} ">
-                    <i class="fas fa-trash"></i>
-                </button>
-            </form>
-        </div>
-        <table class="table table-sm">
-            <tr class="thead">
-                <td style="width: 20%;">Prefix</th>
-                <td style="width: 50%;">Course name</th>
-                <td style="width: 10%;">Credits</th>
-                <td style="width: 10%;">Cat</th>
-                <td style="width: 10%;">Action</th>
-            </tr>
-        </table>
-        <br />
-        {% for each_sem in range(3) %}
-        {% if each_sem == 0 %}
-        <p class="sem">Fall</p>
-        {% set term = 'fall' %}
-        {% elif each_sem == 1 %}
-        <p class="sem">Spring</p>
-        {% set term = 'spring' %}
-        {% else %}
-        <p class="sem">Summer</p>
-        {% set term = 'summer' %}
-        {% endif %}
-        <table class="table table-sm table-hover">
-                <form method="POST">
+                            <span class="year">Year {{each_year}}</span>
+                            <button class="remove" type="submit" name="remove_year" value=" Remove  {{each_year}} ">
+                                <i class="fas fa-trash no-print"></i>
+                            </button>
+                        </form>
+                    </div>
+                    <table class="table table-sm">
+                        <tr class="thead">
+                            <td style="width: 20%;">Prefix</th>
+                            <td style="width: 50%;">Course name</th>
+                            <td style="width: 10%;">Credits</th>
+                            <td style="width: 10%;">Cat</th>
+                            <td class= "no-print" style="width: 10%;">Action</th>
+                        </tr>
+                    </table>
+                    <br />
+                    {% for each_sem in range(3) %}
+                    {% if each_sem == 0 %}
+                    <p class="sem">Fall</p>
+                    {% set term = 'fall' %}
+                    {% elif each_sem == 1 %}
+                    <p class="sem">Spring</p>
+                    {% set term = 'spring' %}
+                    {% else %}
+                    <p class="sem">Summer</p>
+                    {% set term = 'summer' %}
+                    {% endif %}
+                    <table class="table table-sm table-hover">
+                        <form method="POST">
 
-                    {% for course_taken in student_info[each_year][term] %}
-                    <!-- <button > -->
-                    {% set c_num = course_taken['c_number'] %}
-                    {% set notes_text = student_info['notes'][each_year][term][c_num] %}
-                    <tr {% if (c_num in student_info['notes'][each_year][term]) and notes_text|length > 0  %}
-                        class = "notespresent" {% endif %} data-toggle="modal" data-target="#notesModal"
-                        onclick="setTermCourse('{{each_year}}','{{term}}','{{c_num}}','{{notes_text}}');">
+                            {% for course_taken in student_info[each_year][term] %}
+                            <!-- <button > -->
+                            {% set c_num = course_taken['c_number'] %}
+                            {% set notes_text = student_info['notes'][each_year][term][c_num] %}
+                            <tr {% if (c_num in student_info['notes'][each_year][term]) and notes_text|length> 0 %}
+                                class = "notespresent" {% endif %} data-toggle="modal" data-target="#notesModal"
+                                onclick="setTermCourse('{{each_year}}','{{term}}','{{c_num}}','{{notes_text}}');">
 
-                        {% if course_taken['psych']=='1' %}
-                        <td style="width: 20%;">PSYC{{course_taken['c_number']}}</td>
-                        {% else %}
-                        <td style="width: 20%;"> {{ course_taken['c_number'] }} </td>
-                        {% endif %}
-                        <td style="width: 60%;"{% if notes_text %} class="tooltipsss" {% endif %}>
-                            {{course_taken['c_name']}}
-                            <span class="tooltiptextsss">{{notes_text}}</span>
-                        </td>
-                        <td style="width: 5%;">{{course_taken['c_credits']}}</td>
-                        <td style="width: 8%;">{{course_taken['c_category']}}</td>
-                        <td style="width: 7%;"><button style="width:90%" class=" remove" type="submit" name="remove"
-                                value="Remove {{course_taken['c_number']}} for {{term}} in {{each_year}}"><i
-                                    class="fas fa-trash" onclick="event.stopPropagation();"></i></button>
-                        </td>
-                    </tr>
-                    <!-- </button> -->
+                                {% if course_taken['psych']=='1' %}
+                                <td style="width: 20%;">PSYC{{course_taken['c_number']}}</td>
+                                {% else %}
+                                <td style="width: 20%;"> {{ course_taken['c_number'] }} </td>
+                                {% endif %}
+                                <td style="width: 60%;" {% if notes_text %} class="tooltipsss" {% endif %}>
+                                    {{course_taken['c_name']}}
+                                    <span class="tooltiptextsss">{{notes_text}}</span>
+                                </td>
+                                <td style="width: 5%;">{{course_taken['c_credits']}}</td>
+                                <td style="width: 8%;">{{course_taken['c_category']}}</td>
+                                <td class= "no-print" style="width: 7%;"><button style="width:90%" class=" remove" type="submit"
+                                        name="remove"
+                                        value="Remove {{course_taken['c_number']}} for {{term}} in {{each_year}}"><i
+                                            class="fas fa-trash" onclick="event.stopPropagation();"></i></button>
+                                </td>
+                            </tr>
+                            <!-- </button> -->
+                            {% endfor %}
+                        </form>
+
+                        <tr class="no-print">
+                            <form method="POST">
+                                <td>
+                                    <input style="width: 100%;" list="c_number" autocomplete="off" type="text"
+                                        name="c_number" placeholder="--">
+                                    <datalist id="c_number">
+                                        {% for course_number in course_numbers%}
+                                        <option value={{course_number}}>
+                                            {% endfor %}
+                                    </datalist>
+                                </td>
+                                <td>
+                                    <input list="c_name" autocomplete="off" type="text" name="c_name"
+                                        placeholder="select">
+                                    <datalist id="c_name">
+                                        {% for course_name in course_names%}
+                                        <option value="{{course_name}}">
+                                            {% endfor %}
+                                    </datalist>
+                                </td>
+                                <td><input class="form-control-plaintext" style="width: 100%;" type="text"
+                                        name="c_credits" autocomplete="off" placeholder=""></td>
+                                <td><input class="form-control-plaintext" style="width: 100%;" type="text"
+                                        name="c_category" autocomplete="off" placeholder=""></td>
+                                <td>
+                                    <button style="width: 45%;" class="btnSuccess" type="submit" name="add_course"
+                                        value="Add to {{term}} in {{each_year}}"><i class="fas fa-plus"></i></button>
+                                </td>
+                            </form>
+                        </tr>
+                    </table>
                     {% endfor %}
-                </form>
-
-                <tr>
-                    <form method="POST">
-                        <td>
-                            <input style="width: 100%;" list="c_number" autocomplete="off" type="text" name="c_number"
-                                placeholder="--">
-                            <datalist id="c_number">
-                                {% for course_number in course_numbers%}
-                                <option value={{course_number}}>
-                                    {% endfor %}
-                            </datalist>
-                        </td>
-                        <td>
-                            <input list="c_name" autocomplete="off" type="text" name="c_name" placeholder="select">
-                            <datalist id="c_name">
-                                {% for course_name in course_names%}
-                                <option value="{{course_name}}">
-                                    {% endfor %}
-                            </datalist>
-                        </td>
-                        <td><input class="form-control-plaintext" style="width: 100%;" type="text" name="c_credits"
-                                autocomplete="off" placeholder=""></td>
-                        <td><input class="form-control-plaintext" style="width: 100%;" type="text" name="c_category"
-                                autocomplete="off" placeholder=""></td>
-                        <td>
-                            <button style="width: 45%;" class="btnSuccess" type="submit" name="add_course"
-                                value="Add to {{term}} in {{each_year}}"><i class="fas fa-plus"></i></button>
-                        </td>
-                    </form>
-                </tr>
-        </table>
+                    <!--for each semester-->
+                </div>
+            </td>
+            {% if loop.cycle('odd','even') == 'even' %}
+        </tr>
+        {% endif %}
         {% endfor %}
-        <!--for each semester-->
-    </div>
-    {% endfor %}
-    <!--for each year-->
-    {% endif %}
-    
+        <!--for each year-->
+        {% endif %}
+
+    </table>
 
     <div id="myModal" class="modal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">
@@ -369,11 +384,13 @@
         </div>
     </div>
 
-    <form method="POST">
+    <form class = "no-print" method="POST">
         <input list="new_year" type="text" name="new_year" autocomplete="off" placeholder="Enter year" is required>
         <input class="btn btn-primary" type="submit" name="year" value="Add a year">
         <datalist id="new_year">
-            {% for year in ["2010-2011", "2011-2012", "2012-2013", "2013-2014", "2014-2015", "2015-2016", "2016-2017", "2017-2018", "2018-2019", "2019-2020", "2020-2021", "2021-2022", "2022-2023", "2023-2024", "2024-2025", "2025-2026", "2026-2027", "2027-2028", "2028-2029", "2029-2030"]%}
+            {% for year in ["2010-2011", "2011-2012", "2012-2013", "2013-2014", "2014-2015", "2015-2016", "2016-2017",
+            "2017-2018", "2018-2019", "2019-2020", "2020-2021", "2021-2022", "2022-2023", "2023-2024", "2024-2025",
+            "2025-2026", "2026-2027", "2027-2028", "2028-2029", "2029-2030"]%}
             <option value="{{year}}">
                 {% endfor %}
         </datalist>
@@ -402,13 +419,13 @@
     <!-- bootstrap script tags-->
     <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
         integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous">
-    </script>
+        </script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous">
-    </script>
+        </script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"
         integrity="sha384-wfSDF2E50Y2D1uUdj0O3uMBJnjuUD4Ih7YwaYd1iqfktj0Uod8GCExl3Og8ifwB6" crossorigin="anonymous">
-    </script>
+        </script>
 
 </body>
 

--- a/templates/main.html
+++ b/templates/main.html
@@ -45,13 +45,11 @@
             {% endfor %}
         </form>
     </table>
-        <form class="form" method="POST">
+        <form class="form" method="POST" style="padding:50px;">
 
             <h5>Add new student:</h5>
 
             <input type="text" name="name" placeholder="Enter Name" required>
-
-            <input type="text" name="image_link" placeholder="(Optional) Image link">
 
             <input list="year_of_joining" type="text" name="year_of_joining" placeholder="Enter Year Of Joining" required>
             <datalist id="year_of_joining">


### PR DESCRIPTION
Problem:
1. Every year was sliding into the next one, and this caused gaps when the years were not the same length.
2. Clicking on the print button caused everything on the page to print, including unnecessary buttons and forms.

Solution:
1. Put the years in a table to ensure same height for new rows.
2. Added a no-print class and a new css file 